### PR TITLE
Show buy page when not connected and set containers pagination to 100

### DIFF
--- a/packages/nextjs/app/buy/page.tsx
+++ b/packages/nextjs/app/buy/page.tsx
@@ -8,7 +8,7 @@ import { KudzuContainer } from "~~/components/KudzuContainer";
 const Buy: NextPage = () => {
   const ContainersQuery = gql`
     query Containers($after: String, $before: String) {
-      containers(limit: 50, before: $before, after: $after) {
+      containers(limit: 100, before: $before, after: $after) {
         items {
           owner
           contract

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -102,7 +102,7 @@ const Home: NextPage = () => {
         </div>
       </div>
       <div className="divider p-12"></div>
-      {yourKudzuTokenId ? (
+      {yourKudzuTokenId && (
         <div className="flex items-center flex-col flex-grow pt-10">
           <h1 className="text-center">
             <div className="content-center"> 🦠 YOU ARE INFECTED WITH KUDZU:</div>
@@ -133,44 +133,44 @@ const Home: NextPage = () => {
             🦠 infect from your kudzu
           </button>
           <div className="divider p-12"></div>
-          <div>
-            <button
-              className="btn btn-secondary"
-              onClick={() => {
-                router.push("/buy");
-              }}
-            >
-              💵 buy kudzu containers
-            </button>
-          </div>
-          <div className="divider p-12"></div>
-          <div>
-            <button
-              className="btn btn-secondary"
-              onClick={() => {
-                deployContainer();
-              }}
-            >
-              🧫 deploy a kudzu container smart contract
-            </button>
-
-            {containerRender}
-          </div>
-          <div className="divider p-12"></div>
-          <div>
-            <button
-              className="btn btn-secondary"
-              onClick={() => {
-                router.push("/debug");
-              }}
-            >
-              📄 smart contracts
-            </button>
-          </div>
         </div>
-      ) : (
-        ""
       )}
+      <div className="flex items-center flex-col flex-grow pt-10">
+        <div>
+          <button
+            className="btn btn-secondary"
+            onClick={() => {
+              router.push("/buy");
+            }}
+          >
+            💵 buy kudzu containers
+          </button>
+        </div>
+        <div className="divider p-12"></div>
+        <div>
+          <button
+            className="btn btn-secondary"
+            onClick={() => {
+              deployContainer();
+            }}
+          >
+            🧫 deploy a kudzu container smart contract
+          </button>
+
+          {containerRender}
+        </div>
+        <div className="divider p-12"></div>
+        <div>
+          <button
+            className="btn btn-secondary"
+            onClick={() => {
+              router.push("/debug");
+            }}
+          >
+            📄 smart contracts
+          </button>
+        </div>
+      </div>
     </>
   );
 };

--- a/packages/nextjs/components/KudzuContainer.tsx
+++ b/packages/nextjs/components/KudzuContainer.tsx
@@ -6,6 +6,7 @@ import { BalanceValue } from "./scaffold-eth/BalanceValue";
 import { Abi } from "abitype";
 import { formatEther, parseEther } from "viem";
 import { useAccount, useContractRead, useContractWrite } from "wagmi";
+import { RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 import { useDeployedContractInfo, useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 
@@ -146,7 +147,7 @@ export const KudzuContainer = ({ contractAddress, mustBeForSale, mustBeOwnedBy }
               ""
             )}
           </div>
-        ) : (
+        ) : address ? (
           <button
             className={"btn"}
             onClick={() => {
@@ -155,6 +156,8 @@ export const KudzuContainer = ({ contractAddress, mustBeForSale, mustBeOwnedBy }
           >
             💵 buy for <BalanceValue value={price ? formatEther(price) : "0"} usdMode={true} />
           </button>
+        ) : (
+          <RainbowKitCustomConnectButton text="Connect Wallet to Buy" />
         )}
       </>
     </div>

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -14,7 +14,7 @@ import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 /**
  * Custom Wagmi Connect Button (watch balance + custom design)
  */
-export const RainbowKitCustomConnectButton = () => {
+export const RainbowKitCustomConnectButton = ({ text }: { text?: string }) => {
   useAutoConnect();
   const networkColor = useNetworkColor();
   const { targetNetwork } = useTargetNetwork();
@@ -33,7 +33,7 @@ export const RainbowKitCustomConnectButton = () => {
               if (!connected) {
                 return (
                   <button className="btn btn-primary btn-sm" onClick={openConnectModal} type="button">
-                    Connect Wallet
+                    {text || "Connect Wallet"}
                   </button>
                 );
               }


### PR DESCRIPTION
This is how the home page looks now when the wallet is not connected:

![localhost_3002_ (2)](https://github.com/austintgriffith/kudzu-exchange/assets/466652/e80ab3e2-20f9-44c2-aa76-c799b86605ed)

The buy button allows you to connect the wallet.

![localhost_3002_buy](https://github.com/austintgriffith/kudzu-exchange/assets/466652/1dbe52f2-7659-4e3a-9f95-dedbf83cc970)

This PR increased items per page on the buy page too.